### PR TITLE
Fix a typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ For OpenCart CMS you can use this:
 - Apache
 
 ```apache
-# for VeuFront to work you need to load index.html before any other index file
+# for VueFront to work you need to load index.html before any other index file
 DirectoryIndex index.html index.php
 
 ```
 
 - Nginx
 ```nginx
-# for VeuFront to work you need to load index.html before any other index file
+# for VueFront to work you need to load index.html before any other index file
 index index.html index.php;
 
 # when visiting any other url, it should forward to the root index.html file


### PR DESCRIPTION
Looks like the `Vue` name in a code comment was not right.